### PR TITLE
Create SerializableXMLTest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "SimpleSAML\\XML\\": ["tests", "tests/src"]
+            "SimpleSAML\\Test\\XML\\": ["tests", "tests/src"]
         }
     },
     "require": {

--- a/tests/ArrayizableXMLTest.php
+++ b/tests/ArrayizableXMLTest.php
@@ -24,9 +24,11 @@ abstract class ArrayizableXMLTest extends SerializableXMLTest
     public function testArrayization(): void
     {
         $element = static::$element;
+
+        /** @psalm-var array|null $arrayRepresentation */
         $arrayRepresentation = static::$arrayRepresentation;
 
-        if ($element === null || !class_exists($element)) {
+        if (!class_exists($element)) {
             $this->markTestSkipped(
                 'Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class
                 . ':$element to a class-string representing the XML-class being tested'

--- a/tests/ArrayizableXMLTest.php
+++ b/tests/ArrayizableXMLTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\XML;
+
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for ArrayizableXML classes to perform default serialization tests.
+ *
+ * @package simplesamlphp\xml-common
+ */
+abstract class ArrayizableXMLTest extends SerializableXMLTest
+{
+    /** @var array */
+    protected static array $arrayRepresentation;
+
+
+    /**
+     * Test arrayization / de-arrayization
+     */
+    public function testArrayization(): void
+    {
+        $element = static::$element;
+        $arrayRepresentation = static::$arrayRepresentation;
+
+        if ($element === null || !class_exists($element)) {
+            $this->markTestSkipped(
+                'Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class
+                . ':$element to a class-string representing the XML-class being tested'
+            );
+        } elseif ($arrayRepresentation === null) {
+            $this->markTestSkipped(
+                'Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class
+                . ':$arrayRepresentation to an array representing the XML-class being tested'
+            );
+        } else {
+            $this->assertEquals(
+                $arrayRepresentation,
+                $element::fromArray($arrayRepresentation)->toArray(),
+            );
+        }
+    }
+}

--- a/tests/SerializableXMLTest.php
+++ b/tests/SerializableXMLTest.php
@@ -8,9 +8,8 @@ use DOMDocument;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test for AbstractSerializableXML classes to perform default serialization tests.
+ * Test for SerializableXML classes to perform default serialization tests.
  *
- * @runTestsInSeparateProcesses
  * @package simplesamlphp\xml-common
  */
 abstract class SerializableXMLTest extends TestCase
@@ -19,10 +18,10 @@ abstract class SerializableXMLTest extends TestCase
     protected static string $element;
 
     /** @var \DOMDocument */
-    protected static DOMDocument $xmlDocument;
+    protected static DOMDocument $xmlRepresentation;
 
     /** @var array */
-    protected static array $arrayDocument;
+    protected static array $arrayRepresentation;
 
 
     /**
@@ -31,16 +30,22 @@ abstract class SerializableXMLTest extends TestCase
     public function testSerialization(): void
     {
         $element = static::$element;
-        $document = static::$xmlDocument;
+        $xmlRepresentation = static::$xmlRepresentation;
 
         if ($element === null || !class_exists($element)) {
-            $this->markTestSkipped('Unable to run ' . static::class . '::testSerialization(). Please set ' . static::class . ':$element to a class-string representing the XML-class being tested');
-        } elseif ($document === null) {
-            $this->markTestSkipped('Unable to run ' . static::class . '::testSerialization(). Please set ' . static::class . ':$xmlDocument to a DOMDocument representing the XML-class being tested');
+            $this->markTestSkipped(
+                'Unable to run ' . static::class . '::testSerialization(). Please set ' . static::class
+                . ':$element to a class-string representing the XML-class being tested'
+            );
+        } elseif ($xmlRepresentation === null) {
+            $this->markTestSkipped(
+                'Unable to run ' . static::class . '::testSerialization(). Please set ' . static::class
+                . ':$xmlRepresentation to a DOMDocument representing the XML-class being tested'
+            );
         } else {
             $this->assertEquals(
-                $document->saveXML($document->documentElement),
-                strval(unserialize(serialize($element::fromXML($document->documentElement))))
+                $xmlRepresentation->saveXML($xmlRepresentation->documentElement),
+                strval(unserialize(serialize($element::fromXML($xmlRepresentation->documentElement))))
             );
         }
     }
@@ -52,16 +57,22 @@ abstract class SerializableXMLTest extends TestCase
     public function testArrayization(): void
     {
         $element = static::$element;
-        $document = static::$arrayDocument;
+        $arrayRepresentation = static::$arrayRepresentation;
 
         if ($element === null || !class_exists($element)) {
-            $this->markTestSkipped('Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class . ':$element to a class-string representing the XML-class being tested');
-        } elseif ($document === null) {
-            $this->markTestSkipped('Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class . ':$arrayDocument to an array representing the XML-class being tested');
+            $this->markTestSkipped(
+                'Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class
+                . ':$element to a class-string representing the XML-class being tested'
+            );
+        } elseif ($arrayRepresentation === null) {
+            $this->markTestSkipped(
+                'Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class
+                . ':$arrayRepresentation to an array representing the XML-class being tested'
+            );
         } else {
             $this->assertEquals(
-                $document,
-                $element::fromArray($document)->toArray(),
+                $arrayRepresentation,
+                $element::fromArray($arrayRepresentation)->toArray(),
             );
         }
     }

--- a/tests/SerializableXMLTest.php
+++ b/tests/SerializableXMLTest.php
@@ -27,9 +27,11 @@ abstract class SerializableXMLTest extends TestCase
     public function testSerialization(): void
     {
         $element = static::$element;
+
+        /** @psalm-var \DOMDocument|null $xmlRepresentation */
         $xmlRepresentation = static::$xmlRepresentation;
 
-        if ($element === null || !class_exists($element)) {
+        if (!class_exists($element)) {
             $this->markTestSkipped(
                 'Unable to run ' . static::class . '::testSerialization(). Please set ' . static::class
                 . ':$element to a class-string representing the XML-class being tested'

--- a/tests/SerializableXMLTest.php
+++ b/tests/SerializableXMLTest.php
@@ -6,7 +6,6 @@ namespace SimpleSAML\Test\XML;
 
 use DOMDocument;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\XML\AbstractSerializableXML;
 
 /**
  * Test for AbstractSerializableXML classes to perform default serialization tests.
@@ -21,6 +20,10 @@ abstract class SerializableXMLTest extends TestCase
 
     /** @var \DOMDocument */
     protected static DOMDocument $xmlDocument;
+
+    /** @var array */
+    protected static array $arrayDocument;
+
 
     /**
      * Test serialization / unserialization.
@@ -38,6 +41,27 @@ abstract class SerializableXMLTest extends TestCase
             $this->assertEquals(
                 $document->saveXML($document->documentElement),
                 strval(unserialize(serialize($element::fromXML($document->documentElement))))
+            );
+        }
+    }
+
+
+    /**
+     * Test arrayization / de-arrayization
+     */
+    public function testArrayization(): void
+    {
+        $element = static::$element;
+        $document = static::$arrayDocument;
+
+        if ($element === null || !class_exists($element)) {
+            $this->markTestSkipped('Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class . ':$element to a class-string representing the XML-class being tested');
+        } elseif ($document === null) {
+            $this->markTestSkipped('Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class . ':$arrayDocument to an array representing the XML-class being tested');
+        } else {
+            $this->assertEquals(
+                $document,
+                $element::fromArray($document)->toArray(),
             );
         }
     }

--- a/tests/SerializableXMLTest.php
+++ b/tests/SerializableXMLTest.php
@@ -20,9 +20,6 @@ abstract class SerializableXMLTest extends TestCase
     /** @var \DOMDocument */
     protected static DOMDocument $xmlRepresentation;
 
-    /** @var array */
-    protected static array $arrayRepresentation;
-
 
     /**
      * Test serialization / unserialization.
@@ -46,33 +43,6 @@ abstract class SerializableXMLTest extends TestCase
             $this->assertEquals(
                 $xmlRepresentation->saveXML($xmlRepresentation->documentElement),
                 strval(unserialize(serialize($element::fromXML($xmlRepresentation->documentElement))))
-            );
-        }
-    }
-
-
-    /**
-     * Test arrayization / de-arrayization
-     */
-    public function testArrayization(): void
-    {
-        $element = static::$element;
-        $arrayRepresentation = static::$arrayRepresentation;
-
-        if ($element === null || !class_exists($element)) {
-            $this->markTestSkipped(
-                'Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class
-                . ':$element to a class-string representing the XML-class being tested'
-            );
-        } elseif ($arrayRepresentation === null) {
-            $this->markTestSkipped(
-                'Unable to run ' . static::class . '::testArrayization(). Please set ' . static::class
-                . ':$arrayRepresentation to an array representing the XML-class being tested'
-            );
-        } else {
-            $this->assertEquals(
-                $arrayRepresentation,
-                $element::fromArray($arrayRepresentation)->toArray(),
             );
         }
     }

--- a/tests/SerializableXMLTest.php
+++ b/tests/SerializableXMLTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Test\XML;
+
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\XML\AbstractSerializableXML;
+
+/**
+ * Test for AbstractSerializableXML classes to perform default serialization tests.
+ *
+ * @runTestsInSeparateProcesses
+ * @package simplesamlphp\xml-common
+ */
+abstract class SerializableXMLTest extends TestCase
+{
+    /** @var class-string */
+    protected static string $element;
+
+    /** @var \DOMDocument */
+    protected static DOMDocument $xmlDocument;
+
+    /**
+     * Test serialization / unserialization.
+     */
+    public function testSerialization(): void
+    {
+        $element = static::$element;
+        $document = static::$xmlDocument;
+
+        if ($element === null || !class_exists($element)) {
+            $this->markTestSkipped('Unable to run ' . static::class . '::testSerialization(). Please set ' . static::class . ':$element to a class-string representing the XML-class being tested');
+        } elseif ($document === null) {
+            $this->markTestSkipped('Unable to run ' . static::class . '::testSerialization(). Please set ' . static::class . ':$xmlDocument to a DOMDocument representing the XML-class being tested');
+        } else {
+            $this->assertEquals(
+                $document->saveXML($document->documentElement),
+                strval(unserialize(serialize($element::fromXML($document->documentElement))))
+            );
+        }
+    }
+}


### PR DESCRIPTION
Automatically run a serialization-test on classes that extend AbstractXMLElement.
Requires to set `static::$element` and `static::$xmlDocment` to work.