### PR TITLE
Use a slightly more lenient regex for datetime parsing

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -238,7 +238,7 @@ class Utils
         $matches = [];
 
         // We use a very strict regex to parse the timestamp.
-        $regex = '/^(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)T(\\d\\d):(\\d\\d):(\\d\\d)(?:\\.\\d{1,9})?Z$/D';
+        $regex = '/^(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)T(\\d\\d):(\\d\\d):(\\d\\d)(?:\\.\\d{1,9})?Z?$/D';
         if (preg_match($regex, $time, $matches) == 0) {
             throw new InvalidArgumentException(
                 'Invalid SAML2 timestamp passed to xsDateTimeToTimestamp: ' . $time


### PR DESCRIPTION
Currently datetime parsing requires datetimes to be in a very specific format, namely *yyyy*-*mm*-*dd*T*hh*:*mm*:*ss*[.*sssssssss*]Z.  Crucially, this requires timestamps end with a literal `Z` character, indicating a UTC timezone.  This differs very slightly from [the specification][1] which, in section 1.3.3, calls for all SAML time values to be expressed "with no time zone component", which at least according to [IBM's XML documentation][2], includes the `Z` character denoting UTC timezone.

This is a very small difference, but it means that some SPs may be denied with an error despite being perfectly spec-compliant.  This pull request corrects this, while leaving compatibility with the old format by making the `Z` an optional part of the regex.

Worth noting that I am new to SAML, so if I've made any mistakes in interpreting any of the specs that I've cited, or if there's any other info or changes you need, please let me know.

[1]: https://www.oasis-open.org/committees/download.php/35711/sstc-saml-core-errata-2.0-wd-06-diff.pdf
[2]: https://www.ibm.com/docs/en/i/7.4?topic=types-xsdatetime