### PR TITLE
Normalize elements by dropping their parent objects

### DIFF
--- a/src/AbstractElement.php
+++ b/src/AbstractElement.php
@@ -230,6 +230,10 @@ abstract class AbstractElement implements SerializableElementInterface
                 && $node->namespaceURI === static::getNamespaceURI()
                 && $node->localName === static::getLocalName()
             ) {
+                // Normalize the DOMElement by importing it into a clean empty document
+                $newDoc = DOMDocumentFactory::create();
+                $node = $newDoc->appendChild($newDoc->importNode($node, true));
+
                 $ret[] = static::fromXML($node);
             }
         }

--- a/src/AbstractElement.php
+++ b/src/AbstractElement.php
@@ -232,6 +232,7 @@ abstract class AbstractElement implements SerializableElementInterface
             ) {
                 // Normalize the DOMElement by importing it into a clean empty document
                 $newDoc = DOMDocumentFactory::create();
+                /** @var \DOMElement $node */
                 $node = $newDoc->appendChild($newDoc->importNode($node, true));
 
                 $ret[] = static::fromXML($node);


### PR DESCRIPTION
This takes away the issue that _signed_ elements (like i.e. a SAML2 Assertion) take their history and parent elements with them (like i.e. SAML2 Response) with it.