### PR TITLE
Bugfix: use self instead of static

### DIFF
--- a/src/ExtendableAttributesTrait.php
+++ b/src/ExtendableAttributesTrait.php
@@ -95,8 +95,8 @@ trait ExtendableAttributesTrait
      */
     protected static function getAttributesNSFromXML(DOMElement $xml, NS|array $namespace = null): array
     {
-        $namespace = $namespace ?? static::XS_ANY_ATTR_NAMESPACE;
-        $exclusionList = static::getAttributeExclusions();
+        $namespace = $namespace ?? self::XS_ANY_ATTR_NAMESPACE;
+        $exclusionList = self::getAttributeExclusions();
         $attributes = [];
 
         // Validate namespace value
@@ -107,9 +107,9 @@ trait ExtendableAttributesTrait
             foreach ($xml->attributes as $a) {
                 if (in_array([$a->namespaceURI, $a->localName], $exclusionList, true)) {
                     continue;
-                } elseif ($namespace === NS::OTHER && in_array($a->namespaceURI, [static::NS, null], true)) {
+                } elseif ($namespace === NS::OTHER && in_array($a->namespaceURI, [self::NS, null], true)) {
                     continue;
-                } elseif ($namespace === NS::TARGET && $a->namespaceURI !== static::NS) {
+                } elseif ($namespace === NS::TARGET && $a->namespaceURI !== self::NS) {
                     continue;
                 } elseif ($namespace === NS::LOCAL && $a->namespaceURI !== null) {
                     continue;
@@ -126,7 +126,7 @@ trait ExtendableAttributesTrait
 
             // Replace the ##targetedNamespace with the actual namespace
             if (($key = array_search(NS::TARGET, $namespace)) !== false) {
-                $namespace[$key] = static::NS;
+                $namespace[$key] = self::NS;
             }
 
             // Replace the ##local with null
@@ -195,7 +195,7 @@ trait ExtendableAttributesTrait
 
             // Replace the ##targetedNamespace with the actual namespace
             if (($key = array_search(NS::TARGET, $allowed_namespaces)) !== false) {
-                $allowed_namespaces[$key] = static::NS;
+                $allowed_namespaces[$key] = self::NS;
             }
 
             // Replace the ##local with null
@@ -209,7 +209,7 @@ trait ExtendableAttributesTrait
                 sprintf(
                     'Attributes from namespaces [ %s ] are not allowed inside a %s element.',
                     rtrim(implode(', ', $diff)),
-                    static::NS,
+                    self::NS,
                 ),
             );
         } else {
@@ -218,14 +218,14 @@ trait ExtendableAttributesTrait
                 Assert::allNotNull($actual_namespaces);
 
                 // Must be any namespace other than the parent element
-                Assert::allNotSame($actual_namespaces, static::NS);
+                Assert::allNotSame($actual_namespaces, self::NS);
             } elseif ($namespace === NS::TARGET) {
                 // Must be the same namespace as the one of the parent element
-                Assert::allSame($actual_namespaces, static::NS);
+                Assert::allSame($actual_namespaces, self::NS);
             }
         }
 
-        $exclusionList = static::getAttributeExclusions();
+        $exclusionList = self::getAttributeExclusions();
         foreach ($attributes as $i => $attr) {
             if (in_array([$attr->getNamespaceURI(), $attr->getAttrName()], $exclusionList, true)) {
                 unset($attributes[$i]);
@@ -243,13 +243,13 @@ trait ExtendableAttributesTrait
     public function getAttributeNamespace(): array|NS
     {
         Assert::true(
-            defined('static::XS_ANY_ATTR_NAMESPACE'),
-            self::getClassName(static::class)
+            defined('self::XS_ANY_ATTR_NAMESPACE'),
+            self::getClassName(self::class)
             . '::XS_ANY_ATTR_NAMESPACE constant must be defined and set to the namespace for the xs:anyAttribute.',
             RuntimeException::class,
         );
 
-        return static::XS_ANY_ATTR_NAMESPACE;
+        return self::XS_ANY_ATTR_NAMESPACE;
     }
 
 
@@ -260,8 +260,8 @@ trait ExtendableAttributesTrait
      */
     public static function getAttributeExclusions(): array
     {
-        if (defined('static::XS_ANY_ATTR_EXCLUSIONS')) {
-            return static::XS_ANY_ATTR_EXCLUSIONS;
+        if (defined('self::XS_ANY_ATTR_EXCLUSIONS')) {
+            return self::XS_ANY_ATTR_EXCLUSIONS;
         }
 
         return [];

--- a/src/ExtendableElementTrait.php
+++ b/src/ExtendableElementTrait.php
@@ -44,8 +44,8 @@ trait ExtendableElementTrait
      */
     protected static function getChildElementsFromXML(DOMElement $xml, NS|array $namespace = null): array
     {
-        $namespace = $namespace ?? static::XS_ANY_ELT_NAMESPACE;
-        $exclusionList = static::getElementExclusions();
+        $namespace = $namespace ?? self::XS_ANY_ELT_NAMESPACE;
+        $exclusionList = self::getElementExclusions();
         $registry = ElementRegistry::getInstance();
         $elements = [];
 
@@ -59,9 +59,9 @@ trait ExtendableElementTrait
                     continue;
                 } elseif (in_array([$elt->namespaceURI, $elt->localName], $exclusionList, true)) {
                     continue;
-                } elseif ($namespace === NS::OTHER && in_array($elt->namespaceURI, [static::NS, null], true)) {
+                } elseif ($namespace === NS::OTHER && in_array($elt->namespaceURI, [self::NS, null], true)) {
                     continue;
-                } elseif ($namespace === NS::TARGET && $elt->namespaceURI !== static::NS) {
+                } elseif ($namespace === NS::TARGET && $elt->namespaceURI !== self::NS) {
                     continue;
                 } elseif ($namespace === NS::LOCAL && $elt->namespaceURI !== null) {
                     continue;
@@ -79,7 +79,7 @@ trait ExtendableElementTrait
 
             // Replace the ##targetedNamespace with the actual namespace
             if (($key = array_search(NS::TARGET, $namespace)) !== false) {
-                $namespace[$key] = static::NS;
+                $namespace[$key] = self::NS;
             }
 
             // Replace the ##local with null
@@ -149,7 +149,7 @@ trait ExtendableElementTrait
 
             // Replace the ##targetedNamespace with the actual namespace
             if (($key = array_search(NS::TARGET, $allowed_namespaces)) !== false) {
-                $allowed_namespaces[$key] = static::NS;
+                $allowed_namespaces[$key] = self::NS;
             }
 
             // Replace the ##local with null
@@ -163,21 +163,21 @@ trait ExtendableElementTrait
                 sprintf(
                     'Elements from namespaces [ %s ] are not allowed inside a %s element.',
                     rtrim(implode(', ', $diff)),
-                    static::NS,
+                    self::NS,
                 ),
             );
         } elseif ($namespace === NS::OTHER) {
             // Must be any namespace other than the parent element, excluding elements with no namespace
             Assert::notInArray(null, $actual_namespaces);
-            Assert::allNotSame($actual_namespaces, static::NS);
+            Assert::allNotSame($actual_namespaces, self::NS);
         } elseif ($namespace === NS::TARGET) {
             // Must be the same namespace as the one of the parent element
-            Assert::allSame($actual_namespaces, static::NS);
+            Assert::allSame($actual_namespaces, self::NS);
         } else {
             // XS_ANY_NS_ANY
         }
 
-        $exclusionList = static::getElementExclusions();
+        $exclusionList = self::getElementExclusions();
         foreach ($elements as $i => $elt) {
             if (in_array([$elt->getNamespaceURI(), $elt->getLocalName()], $exclusionList, true)) {
                 unset($elements[$i]);
@@ -205,13 +205,13 @@ trait ExtendableElementTrait
     public function getElementNamespace(): array|NS
     {
         Assert::true(
-            defined('static::XS_ANY_ELT_NAMESPACE'),
-            self::getClassName(static::class)
+            defined('self::XS_ANY_ELT_NAMESPACE'),
+            self::getClassName(self::class)
             . '::XS_ANY_ELT_NAMESPACE constant must be defined and set to the namespace for the xs:any element.',
             RuntimeException::class,
         );
 
-        return static::XS_ANY_ELT_NAMESPACE;
+        return self::XS_ANY_ELT_NAMESPACE;
     }
 
 
@@ -222,8 +222,8 @@ trait ExtendableElementTrait
      */
     public static function getElementExclusions(): array
     {
-        if (defined('static::XS_ANY_ELT_EXCLUSIONS')) {
-            return static::XS_ANY_ELT_EXCLUSIONS;
+        if (defined('self::XS_ANY_ELT_EXCLUSIONS')) {
+            return self::XS_ANY_ELT_EXCLUSIONS;
         }
 
         return [];

--- a/tests/Utils/ExtendableAttributesElement.php
+++ b/tests/Utils/ExtendableAttributesElement.php
@@ -20,7 +20,6 @@ class ExtendableAttributesElement extends AbstractElement
 {
     use ExtendableAttributesTrait;
 
-
     /** @var string */
     public const NS = 'urn:x-simplesamlphp:namespace';
 
@@ -31,34 +30,12 @@ class ExtendableAttributesElement extends AbstractElement
     public const LOCALNAME = 'ExtendableAttributesElement';
 
     /** @var string|\SimpleSAML\XML\XsNamespace */
-    public const XS_ANY_ATTR_NAMESPACE = NS::ANY;
+    final public const XS_ANY_ATTR_NAMESPACE = NS::ANY;
 
     /** @var array{array{string, string}} */
-    public const XS_ANY_ATTR_EXCLUSIONS = [
+    final public const XS_ANY_ATTR_EXCLUSIONS = [
         ['urn:x-simplesamlphp:namespace', 'attr3'],
     ];
-
-
-    /**
-     * Get the namespace for the element.
-     *
-     * @return string
-     */
-    public static function getNamespaceURI(): string
-    {
-        return static::NS;
-    }
-
-
-    /**
-     * Get the namespace-prefix for the element.
-     *
-     * @return string
-     */
-    public static function getNamespacePrefix(): string
-    {
-        return static::NS_PREFIX;
-    }
 
 
     /**

--- a/tests/Utils/ExtendableElement.php
+++ b/tests/Utils/ExtendableElement.php
@@ -6,7 +6,6 @@ namespace SimpleSAML\Test\XML;
 
 use DOMElement;
 use SimpleSAML\XML\AbstractElement;
-use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\ExtendableElementTrait;
 use SimpleSAML\XML\SerializableElementTrait;
 use SimpleSAML\XML\XsNamespace as NS;
@@ -21,7 +20,6 @@ class ExtendableElement extends AbstractElement
     use ExtendableElementTrait;
     use SerializableElementTrait;
 
-
     /** @var string */
     public const NS = 'urn:x-simplesamlphp:namespace';
 
@@ -32,34 +30,12 @@ class ExtendableElement extends AbstractElement
     public const LOCALNAME = 'ExtendableElement';
 
     /** @var \SimpleSAML\XML\XsNamespace|array<int, \SimpleSAML\XML\XsNamespace> */
-    public const XS_ANY_ELT_NAMESPACE = NS::ANY;
+    final public const XS_ANY_ELT_NAMESPACE = NS::ANY;
 
     /** @var array{array{string, string}} */
-    public const XS_ANY_ELT_EXCLUSIONS = [
+    final public const XS_ANY_ELT_EXCLUSIONS = [
         ['urn:custom:other', 'Chunk'],
     ];
-
-
-    /**
-     * Get the namespace for the element.
-     *
-     * @return string
-     */
-    public static function getNamespaceURI(): string
-    {
-        return static::NS;
-    }
-
-
-    /**
-     * Get the namespace-prefix for the element.
-     *
-     * @return string
-     */
-    public static function getNamespacePrefix(): string
-    {
-        return static::NS_PREFIX;
-    }
 
 
     /**
@@ -81,14 +57,7 @@ class ExtendableElement extends AbstractElement
      */
     public static function fromXML(DOMElement $xml): static
     {
-        $children = [];
-        foreach ($xml->childNodes as $node) {
-            if ($node instanceof DOMElement) {
-                $children[] = Chunk::fromXML($node);
-            }
-        }
-
-        return new static($children);
+        return new static(self::getChildElementsFromXML($xml));
     }
 
 

--- a/tests/XML/ExtendableAttributesTraitTest.php
+++ b/tests/XML/ExtendableAttributesTraitTest.php
@@ -224,22 +224,6 @@ final class ExtendableAttributesTraitTest extends TestCase
 
     /**
      */
-    public function testLocalNamespacePassingTargetThrowsAnException(): void
-    {
-        $this->expectException(AssertionFailedException::class);
-        new class ([self::$target]) extends ExtendableAttributesElement {
-            /** @return array<int, NS>|NS */
-            public function getAtributeNamespace(): array|NS
-            {
-                return NS::LOCAL;
-            }
-        };
-    }
-
-
-
-    /**
-     */
     public function testLocalNamespacePassingOtherThrowsAnException(): void
     {
         $this->expectException(AssertionFailedException::class);


### PR DESCRIPTION
Taken from O'Reilly's:

> The target namespace used to evaluate the special values ##targetNamespace and ##other is the target namespace (or lack of target namespace) of the schema in which the xs:any wildcard is found. This doesn’t change when one schema is imported into another.

By using `static` we would change the meaning of `##other` for elements that use a type-definition from an imported xsd.