### PR TITLE
Allow parsing of very large metadata files again

### DIFF
--- a/src/DOMDocumentFactory.php
+++ b/src/DOMDocumentFactory.php
@@ -26,7 +26,7 @@ final class DOMDocumentFactory
      * @var non-negative-int
      * TODO: Add LIBXML_NO_XXE to the defaults when PHP 8.4.0 + libxml 2.13.0 become generally available
      */
-    public const DEFAULT_OPTIONS = LIBXML_COMPACT | LIBXML_NONET | LIBXML_NSCLEAN;
+    public const DEFAULT_OPTIONS = LIBXML_COMPACT | LIBXML_NONET | LIBXML_NSCLEAN | LIBXML_PARSEHUGE;
 
 
     /**


### PR DESCRIPTION
The option `LIBXML_PARSEHUGE` was probably accidentally removed during commit [d57fba2](https://github.com/simplesamlphp/xml-common/commit/d57fba2e9802533d1c4b834a0032c455b80f07f4).

Alternatively, the option must be passed in [MetaLoader.php](https://github.com/simplesamlphp/simplesamlphp-module-metarefresh/blob/9c2c424ffe44c45f15eb37e71cf8a8269c85f077/src/MetaLoader.php#L463) of `simplesamlphp-module-metarefresh`.