### PR TITLE
Support symfony/finder:^7.1 alongside ~6.4.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,7 +38,7 @@ jobs:
       enable_yamllinter: true
 
   unit-tests-linux:
-    name: "Unit tests, PHP ${{ matrix.php-versions }}, symfony ${{ matrix.symfony }}, ${{ matrix.operating-system }}"
+    name: "Tests, PHP ${{ matrix.php-versions }}, symfony ${{ matrix.symfony }}, ${{ matrix.operating-system }}"
     runs-on: ${{ matrix.operating-system }}
     needs: [phplinter, linter]
     strategy:
@@ -108,7 +108,7 @@ jobs:
           path: ${{ github.workspace }}/build
 
   unit-tests-windows:
-    name: "Unit tests, PHP ${{ matrix.php-versions }}, ${{ matrix.operating-system }}"
+    name: "Tests, PHP ${{ matrix.php-versions }}, ${{ matrix.operating-system }}"
     runs-on: ${{ matrix.operating-system }}
     needs: [phplinter, linter]
     strategy:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,14 +38,19 @@ jobs:
       enable_yamllinter: true
 
   unit-tests-linux:
-    name: "Unit tests, PHP ${{ matrix.php-versions }}, ${{ matrix.operating-system }}"
+    name: "Unit tests, PHP ${{ matrix.php-versions }}, symfony ${{ matrix.symfony }}, ${{ matrix.operating-system }}"
     runs-on: ${{ matrix.operating-system }}
     needs: [phplinter, linter]
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4']
+        symfony: ['~6.4.0', '~7.1.0', '^7.3']
+        include:
+          - operating-system: 'ubuntu-latest'
+            php-versions: '8.1'
+            symfony: '~6.4.0'
 
     steps:
       - name: Setup PHP, with composer and extensions
@@ -71,6 +76,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: "Require symfony/finder:${{ matrix.symfony }}"
+        run: composer require --no-update symfony/finder:${{ matrix.symfony }}
+
       - name: Get composer cache directory
         run: echo COMPOSER_CACHE="$(composer config cache-files-dir)" >> "$GITHUB_ENV"
 
@@ -85,15 +93,15 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Run unit tests with coverage
-        if: ${{ matrix.php-versions == '8.4' }}
+        if: ${{ matrix.php-versions == '8.4' && matrix.symfony == '^7.3' }}
         run: vendor/bin/phpunit
 
       - name: Run unit tests (no coverage)
-        if: ${{ matrix.php-versions != '8.4' }}
+        if: ${{ matrix.php-versions != '8.4' || matrix.symfony != '^7.3' }}
         run: vendor/bin/phpunit --no-coverage
 
       - name: Save coverage data
-        if: ${{ matrix.php-versions == '8.4' }}
+        if: ${{ matrix.php-versions == '8.4' && matrix.symfony == '^7.3' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 
         "simplesamlphp/assert": "~1.8.1",
         "simplesamlphp/composer-xmlprovider-installer": "~1.0.2",
-        "symfony/finder": "~6.4.0"
+        "symfony/finder": "~6.4.0 || ^7.1"
     },
     "require-dev": {
         "simplesamlphp/simplesamlphp-test-framework": "~1.9.2"


### PR DESCRIPTION
I found that all the tests still pass with symfony/finder:^7.3. (and possibly lower, I did not try.)

We need this because we want to use simplesamlphp with Drupal 11, which requires symfony/*:^7.3.
We are ok to use a fork for the time being, but it would be much better to have this in upstream.

I am not sure how dependabot will like this.

Also, we could discuss if we want `^6.4.0|^7.3` instead of `~6.4.0|^7.3` for symfony/finder. With the `~` it won't allow `6.5.*` if/when that comes out.
