### PR TITLE
(mistake, sorry) Prepare fork

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -245,6 +245,8 @@ jobs:
         run: composer audit
 
   coverage:
+    # Disable code coverage upload in the fork repository, for now.
+    if: false
     name: Code coverage
     runs-on: [ubuntu-latest]
     needs: [unit-tests-linux]


### PR DESCRIPTION
Tweak github actions to pass in the fork.

Especially:
We don't have an account in codecov.io.
We could create one, but then we'd have to also update the README.md to point to our codecov.io instead of the one for the parent repository. We can do all this, but not in the first version of this fork.