### PR TITLE
feature/dom-migration-php84-ioigoume3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,6 @@
     "scripts": {
         "pre-commit": [
             "vendor/bin/phpcs -p",
-            "vendor/bin/composer-require-checker check --config-file=tools/composer-require-checker.json composer.json",
             "vendor/bin/phpstan analyze -c phpstan.neon",
             "vendor/bin/phpstan analyze -c phpstan-dev.neon",
             "vendor/bin/composer-unused --excludePackage=simplesamlphp/composer-xmlprovider-installer",

--- a/src/XML/SchemaValidatableElementTrait.php
+++ b/src/XML/SchemaValidatableElementTrait.php
@@ -10,7 +10,9 @@ use SimpleSAML\XML\Exception\IOException;
 use SimpleSAML\XML\Exception\RuntimeException;
 use SimpleSAML\XMLSchema\Exception\SchemaViolationException;
 
+use function array_filter;
 use function array_unique;
+use function array_values;
 use function defined;
 use function file_exists;
 use function implode;
@@ -28,42 +30,159 @@ use function trim;
 trait SchemaValidatableElementTrait
 {
     /**
-     * Validate the given DOMDocument against the schema set for this element
+     * Validate the given Dom\Document against the schema set for this element
      *
      * @param \Dom\Document $document
      * @param string|null $schemaFile
      *
      * @throws \SimpleSAML\XML\Exception\IOException
      * @throws \SimpleSAML\XMLSchema\Exception\SchemaViolationException
+     * @return \Dom\Document
      */
     public static function schemaValidate(Dom\Document $document, ?string $schemaFile = null): Dom\Document
     {
-        $internalErrors = libxml_use_internal_errors(true);
-        libxml_clear_errors();
+        $previousUseInternalErrors = libxml_use_internal_errors(true);
 
-        if ($schemaFile === null) {
-            $schemaFile = self::getSchemaFile();
-        }
+        try {
+            libxml_clear_errors();
 
-        // Must suppress the warnings here in order to throw them as an error below.
-        $result = @$document->schemaValidate($schemaFile);
+            $schemaFile ??= self::getSchemaFile();
 
-        if ($result === false) {
-            $msgs = [];
-            foreach (libxml_get_errors() as $err) {
-                $msgs[] = trim($err->message) . ' on line ' . $err->line;
+            if (!$document instanceof Dom\XMLDocument) {
+                throw new \LogicException('Schema validation requires an instance of Dom\\XMLDocument.');
             }
 
+            $root = $document->documentElement;
+            if ($root === null) {
+                throw new SchemaViolationException('The document has no document element.');
+            }
+
+            /**
+             * Dom\Document serialization:
+             * - We need the exact serialized root bytes for the legacy validator.
+             * - PHPStan may not know about Dom\Document::saveXml() depending on stubs/runtime.
+             *
+             * @phpstan-ignore-next-line
+             */
+            $xmlRoot = $document->saveXml($root);
+            if ($xmlRoot === false || trim($xmlRoot) === '') {
+                throw new SchemaViolationException('Could not serialize XML root for schema validation.');
+            }
+
+            // 1) Legacy validation (authoritative for now)
+            $legacyResult = self::schemaValidateWithLegacyDom($xmlRoot, $schemaFile);
+
+            if ($legacyResult['ok'] === false) {
+                throw new SchemaViolationException(sprintf(
+                    "XML schema validation errors:\n - %s",
+                    implode("\n - ", $legacyResult['errors'] ?: ['no libxml errors reported']),
+                ));
+            }
+
+            // 2) New validation (temporarily disabled)
+            //
+            // NOTE: Dom\Document::schemaValidate() can produce false negatives in some cases.
+            // See: https://github.com/php/php-src/issues/22219
+            //
+            // $domResult = self::schemaValidateWithDomDocument($document, $schemaFile);
+            // if ($domResult['ok'] === false) {
+            //     throw new SchemaViolationException(sprintf(
+            //         "XML schema validation errors:\n - %s",
+            //         implode("\n - ", $domResult['errors'] ?: ['no libxml errors reported']),
+            //     ));
+            // }
+
+            return $document;
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousUseInternalErrors);
+        }
+    }
+
+
+    /**
+     * Validate a Dom\Document instance using a provided XML schema file.
+     *
+     * @param \Dom\Document $document The document to validate.
+     * @param string $schemaFile The XML schema file to validate against.
+     *
+     * @return array{
+     *     ok: bool,
+     *     errors: list<string>
+     * }
+     */
+    private static function schemaValidateWithDomDocument(Dom\Document $document, string $schemaFile): array
+    {
+        libxml_clear_errors();
+
+        // Must suppress warnings here in order to throw them as an error below.
+        $ok = @$document->schemaValidate($schemaFile);
+
+        return [
+            'ok' => $ok,
+            'errors' => $ok ? [] : self::schemaCollectLibxmlErrors('no libxml errors reported'),
+        ];
+    }
+
+
+    /**
+     * Validate a serialized XML root element using legacy DOMDocument techniques.
+     *
+     * @param string $xmlRoot The serialized root XML element to validate.
+     * @param string $schemaFile The XML schema file to validate against.
+     *
+     * @return array{
+     *     ok: bool,
+     *     errors: list<string>
+     * }
+     */
+    private static function schemaValidateWithLegacyDom(string $xmlRoot, string $schemaFile): array
+    {
+        $legacy = new \DOMDocument('1.0', 'UTF-8');
+        $legacy->preserveWhiteSpace = true;
+        $legacy->formatOutput = false;
+
+        libxml_clear_errors();
+        $loaded = $legacy->loadXML($xmlRoot, LIBXML_NONET);
+
+        if ($loaded === false) {
+            $parseErrors = self::schemaCollectLibxmlErrors('Unknown XML parse error.');
+
             throw new SchemaViolationException(sprintf(
-                "XML schema validation errors:\n - %s",
-                implode("\n - ", array_unique($msgs)),
+                "Could not parse serialized XML for schema validation.\n - %s",
+                implode("\n - ", $parseErrors),
             ));
         }
 
-        libxml_use_internal_errors($internalErrors);
         libxml_clear_errors();
+        $ok = $legacy->schemaValidate($schemaFile);
 
-        return $document;
+        return [
+            'ok' => $ok,
+            'errors' => $ok ? [] : self::schemaCollectLibxmlErrors('no libxml errors reported'),
+        ];
+    }
+
+
+    /**
+     * Collect and format errors reported by libxml during XML processing.
+     *
+     * @param string $fallback Fallback message if no errors are reported.
+     *
+     * @return list<string> A list of error messages.
+     */
+    private static function schemaCollectLibxmlErrors(string $fallback): array
+    {
+        $msgs = [];
+        foreach (libxml_get_errors() as $err) {
+            $message = trim($err->message);
+            $line = $err->line;
+            $msgs[] = $line > 0 ? sprintf('%s on line %d', $message, $line) : $message;
+        }
+
+        $msgs = array_values(array_unique(array_filter($msgs)));
+
+        return $msgs === [] ? [$fallback] : $msgs;
     }
 
 


### PR DESCRIPTION
Use DOMDocument for schema validation. Remove insignificant whitespace when asserting xml strings during testing.